### PR TITLE
feat: field encoding based on contract type

### DIFF
--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_import_contract() {
-        let dashpay_cbor = json_document_to_cbor("../../test/contract/dashpay-contract.json");
+        let dashpay_cbor = json_document_to_cbor("test/contract/dashpay/dashpay-contract.json");
         let contract = Contract::from_cbor(&dashpay_cbor).unwrap();
 
         assert_eq!(contract.document_types.len(), 3);

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -55,8 +55,6 @@ pub struct IndexProperty {
     pub(crate) ascending: bool,
 }
 
-// TODO: Make the error messages uniform
-
 impl Document {
     pub fn from_cbor(document_cbor: &[u8], owner_id: &[u8]) -> Result<Self, Error> {
         // we need to start by verifying that the owner_id is a 256 bit number (32 bytes)
@@ -90,17 +88,14 @@ impl Document {
         document_type_name: &str,
         contract: &Contract,
     ) -> Option<Vec<u8>> {
-        // TODO: Handle errors better
         let value = self.properties.get(key)?;
-        let field_type = contract
-            .document_types
-            .get(document_type_name)
-            .unwrap()
-            .properties
-            .get(key)
-            .unwrap();
-        let raw_value = types::encode_document_field_type(field_type, value).unwrap();
-        return raw_value;
+        let document_type = contract.document_types.get(document_type_name)?;
+        let field_type = document_type.properties.get(key)?;
+        let raw_value = types::encode_document_field_type(field_type, value);
+        if raw_value.is_err() {
+            return None;
+        }
+        return Some(raw_value.expect("confirmed it's not an error")?);
     }
 }
 

--- a/src/contract/types.rs
+++ b/src/contract/types.rs
@@ -1,17 +1,24 @@
 use ciborium::value::{Integer, Value};
 use grovedb::Error;
-use std::borrow::Borrow;
+use serde::{Deserialize, Serialize};
 
-enum DocumentFieldType {
+#[derive(Serialize, Deserialize)]
+pub enum DocumentFieldType {
     Integer,
     String,
     Float,
 }
 
-// What kind of error should be returned if something goes wrong
-// THe value might not match the document field type is that corrupted data??
-// Yeah corrupted data
-// If the value match then encoding should work, so only one type of error really
+fn string_to_field_type(field_type_name: String) -> Option<DocumentFieldType> {
+    return match field_type_name.as_str() {
+        "integer" => Some(DocumentFieldType::Integer),
+        "string" => Some(DocumentFieldType::String),
+        "float" => Some(DocumentFieldType::Float),
+        _ => None,
+    }
+}
+
+// Given a field type this function chooses and executes the right encoding method
 fn encode_document_field_type(
     field_type: DocumentFieldType,
     value: &Value,

--- a/src/contract/types.rs
+++ b/src/contract/types.rs
@@ -14,12 +14,12 @@ pub fn string_to_field_type(field_type_name: String) -> Option<DocumentFieldType
         "integer" => Some(DocumentFieldType::Integer),
         "string" => Some(DocumentFieldType::String),
         "float" => Some(DocumentFieldType::Float),
-        "array" => Some(DocumentFieldType::String),
+        "array" => Some(DocumentFieldType::String), // TODO: Create bytearray type
         _ => None,
     };
 }
 
-// Given a field type this function chooses and executes the right encoding method
+// Given a field type and a value this function chooses and executes the right encoding method
 pub fn encode_document_field_type(
     field_type: &DocumentFieldType,
     value: &Value,

--- a/src/contract/types.rs
+++ b/src/contract/types.rs
@@ -9,20 +9,21 @@ pub enum DocumentFieldType {
     Float,
 }
 
-fn string_to_field_type(field_type_name: String) -> Option<DocumentFieldType> {
+pub fn string_to_field_type(field_type_name: String) -> Option<DocumentFieldType> {
     return match field_type_name.as_str() {
         "integer" => Some(DocumentFieldType::Integer),
         "string" => Some(DocumentFieldType::String),
         "float" => Some(DocumentFieldType::Float),
+        "array" => Some(DocumentFieldType::String),
         _ => None,
-    }
+    };
 }
 
 // Given a field type this function chooses and executes the right encoding method
-fn encode_document_field_type(
-    field_type: DocumentFieldType,
+pub fn encode_document_field_type(
+    field_type: &DocumentFieldType,
     value: &Value,
-) -> Result<Vec<u8>, Error> {
+) -> Result<Option<Vec<u8>>, Error> {
     let field_type_match_error = Error::CorruptedData(String::from(
         "document field type doesn't match document value",
     ));
@@ -30,18 +31,18 @@ fn encode_document_field_type(
     return match field_type {
         DocumentFieldType::String => {
             let value_as_text = value.as_text().ok_or(field_type_match_error)?;
-            Ok(value_as_text.as_bytes().to_vec())
+            Ok(Some(value_as_text.as_bytes().to_vec()))
         }
         DocumentFieldType::Integer => {
             let value_as_integer = value.as_integer().ok_or(field_type_match_error)?;
             let value_as_u64: u64 = value_as_integer
                 .try_into()
                 .map_err(|_| Error::CorruptedData(String::from("expected integer value")))?;
-            Ok(value_as_u64.to_be_bytes().to_vec())
+            Ok(Some(value_as_u64.to_be_bytes().to_vec()))
         }
         DocumentFieldType::Float => {
             let value_as_float = value.as_float().ok_or(field_type_match_error)?;
-            Ok(value_as_float.to_be_bytes().to_vec())
+            Ok(Some(value_as_float.to_be_bytes().to_vec()))
         }
     };
 }
@@ -59,9 +60,9 @@ mod tests {
         let string1 = Value::Text(String::from("a"));
         let string2 = Value::Text(String::from("b"));
 
-        let encoded_string1 = encode_document_field_type(DocumentFieldType::String, &string1)
+        let encoded_string1 = encode_document_field_type(&DocumentFieldType::String, &string1)
             .expect("should encode: valid parameters");
-        let encoded_string2 = encode_document_field_type(DocumentFieldType::String, &string2)
+        let encoded_string2 = encode_document_field_type(&DocumentFieldType::String, &string2)
             .expect("should encode: valid parameters");
 
         assert_eq!(string1 > string2, encoded_string1 > encoded_string2);
@@ -71,11 +72,11 @@ mod tests {
         let float2 = Value::Float(121.1);
         let float3 = Value::Float(13.0);
 
-        let encoded_float1 = encode_document_field_type(DocumentFieldType::Float, &float1)
+        let encoded_float1 = encode_document_field_type(&DocumentFieldType::Float, &float1)
             .expect("should encode: valid parameters");
-        let encoded_float2 = encode_document_field_type(DocumentFieldType::Float, &float2)
+        let encoded_float2 = encode_document_field_type(&DocumentFieldType::Float, &float2)
             .expect("should encode: valid parameters");
-        let encoded_float3 = encode_document_field_type(DocumentFieldType::Float, &float3)
+        let encoded_float3 = encode_document_field_type(&DocumentFieldType::Float, &float3)
             .expect("should encode: valid parameters");
 
         // 11.0 < 121.1
@@ -90,11 +91,11 @@ mod tests {
         let integer2 = Value::Integer(Integer::from(60));
         let integer3 = Value::Integer(Integer::from(60));
 
-        let encoded_integer1 = encode_document_field_type(DocumentFieldType::Integer, &integer1)
+        let encoded_integer1 = encode_document_field_type(&DocumentFieldType::Integer, &integer1)
             .expect("should encode: valid parameters");
-        let encoded_integer2 = encode_document_field_type(DocumentFieldType::Integer, &integer2)
+        let encoded_integer2 = encode_document_field_type(&DocumentFieldType::Integer, &integer2)
             .expect("should encode: valid parameters");
-        let encoded_integer3 = encode_document_field_type(DocumentFieldType::Integer, &integer3)
+        let encoded_integer3 = encode_document_field_type(&DocumentFieldType::Integer, &integer3)
             .expect("should encode: valid parameters");
 
         assert_eq!(encoded_integer1 < encoded_integer2, true);

--- a/src/contract/types.rs
+++ b/src/contract/types.rs
@@ -1,0 +1,79 @@
+use ciborium::value::{Integer, Value};
+use grovedb::Error;
+use std::borrow::Borrow;
+
+enum DocumentFieldType {
+    Integer,
+    String,
+    Float,
+}
+
+// What kind of error should be returned if something goes wrong
+// THe value might not match the document field type is that corrupted data??
+// Yeah corrupted data
+// If the value match then encoding should work, so only one type of error really
+fn encode_document_field_type(
+    field_type: DocumentFieldType,
+    value: &Value,
+) -> Result<Vec<u8>, Error> {
+    let field_type_match_error = Error::CorruptedData(String::from(
+        "document field type doesn't match document value",
+    ));
+
+    return match field_type {
+        DocumentFieldType::String => {
+            let value_as_text = value.as_text().ok_or(field_type_match_error)?;
+            Ok(value_as_text.as_bytes().to_vec())
+        }
+        DocumentFieldType::Integer => {
+            let value_as_integer = value.as_integer().ok_or(field_type_match_error)?;
+            let value_as_u64: u64 = value_as_integer.try_into().unwrap();
+            Ok(value_as_u64.to_be_bytes().to_vec())
+        }
+        DocumentFieldType::Float => {
+            let value_as_float = value.as_float().ok_or(field_type_match_error)?;
+            Ok(value_as_float.to_be_bytes().to_vec())
+        }
+    };
+}
+
+mod tests {
+    use crate::contract::types::{encode_document_field_type, DocumentFieldType};
+    use ciborium::value::Value;
+
+    #[test]
+    fn test_successful_encode() {
+        // TODO: Add more edge cases
+        // Constraint: for all types, if a > b then encoding(a) > enconding(b)
+
+        // String encoding
+        let string1 = Value::Text(String::from("a"));
+        let string2 = Value::Text(String::from("b"));
+
+        let encoded_string1 = encode_document_field_type(DocumentFieldType::String, &string1)
+            .expect("should encode: valid parameters");
+        let encoded_string2 = encode_document_field_type(DocumentFieldType::String, &string2)
+            .expect("should encode: valid parameters");
+
+        assert_eq!(string1 > string2, encoded_string1 > encoded_string2);
+
+        // Float encoding
+        let float1 = Value::Float(11.0);
+        let float2 = Value::Float(121.1);
+        let float3 = Value::Float(13.0);
+
+        let encoded_float1 = encode_document_field_type(DocumentFieldType::Float, &float1)
+            .expect("should encode: valid parameters");
+        let encoded_float2 = encode_document_field_type(DocumentFieldType::Float, &float2)
+            .expect("should encode: valid parameters");
+        let encoded_float3 = encode_document_field_type(DocumentFieldType::Float, &float3)
+            .expect("should encode: valid parameters");
+
+        // 11.0 < 121.1
+        assert_eq!(encoded_float1 < encoded_float2, true);
+        // 121.1 > 13.0
+        assert_eq!(encoded_float2 > encoded_float3, true);
+        // 13.0 > 11.0
+        assert_eq!(encoded_float3 > encoded_float1, true);
+    }
+}

--- a/src/drive/mod.rs
+++ b/src/drive/mod.rs
@@ -378,7 +378,11 @@ impl Drive {
                 }
                 &_ => {
                     document_top_field = document
-                        .get_raw_for_contract(&top_index_property.name, &contract)
+                        .get_raw_for_contract(
+                            &top_index_property.name,
+                            document_type_name,
+                            &contract,
+                        )
                         .ok_or(Error::CorruptedData(String::from(
                             "unable to get document top index field",
                         )))?;
@@ -422,7 +426,7 @@ impl Drive {
                 // Iteration 2. the index path is now something like Contracts/ContractID/Documents(1)/$ownerId/<ownerId>/toUserId/<ToUserId>/accountReference
 
                 let document_index_field: Vec<u8> = document
-                    .get_raw_for_contract(&index_property.name, &contract)
+                    .get_raw_for_contract(&index_property.name, document_type_name, &contract)
                     .ok_or(Error::CorruptedData(String::from(
                         "unable to get document field",
                     )))?;
@@ -623,7 +627,11 @@ impl Drive {
                 }
                 &_ => {
                     document_top_field = document
-                        .get_raw_for_contract(&top_index_property.name, &contract)
+                        .get_raw_for_contract(
+                            &top_index_property.name,
+                            document_type_name,
+                            &contract,
+                        )
                         .ok_or(Error::CorruptedData(String::from(
                             "unable to get document top index field",
                         )))?;
@@ -648,7 +656,7 @@ impl Drive {
                 // Iteration 2. the index path is now something like Contracts/ContractID/Documents(1)/$ownerId/<ownerId>/toUserId/<ToUserId>/accountReference
 
                 let document_top_field: Vec<u8> = document
-                    .get_raw_for_contract(&index_property.name, &contract)
+                    .get_raw_for_contract(&index_property.name, document_type_name, &contract)
                     .ok_or(Error::CorruptedData(String::from(
                         "unable to get document field",
                     )))?;

--- a/src/drive/mod.rs
+++ b/src/drive/mod.rs
@@ -63,12 +63,29 @@ fn contract_documents_path(contract_id: &[u8]) -> Vec<&[u8]> {
     vec![RootTree::ContractDocuments.into(), contract_id, b"1"]
 }
 
-fn contract_document_type_path<'a>(contract_id: &'a [u8], document_type_name: &'a str) -> Vec<&'a [u8]> {
-    vec![RootTree::ContractDocuments.into(), contract_id, b"1", document_type_name.as_bytes()]
+fn contract_document_type_path<'a>(
+    contract_id: &'a [u8],
+    document_type_name: &'a str,
+) -> Vec<&'a [u8]> {
+    vec![
+        RootTree::ContractDocuments.into(),
+        contract_id,
+        b"1",
+        document_type_name.as_bytes(),
+    ]
 }
 
-fn contract_documents_primary_key_path<'a>(contract_id: &'a [u8], document_type_name: &'a str) -> Vec<&'a [u8]> {
-    vec![RootTree::ContractDocuments.into(), contract_id, b"1", document_type_name.as_bytes(), b"0"]
+fn contract_documents_primary_key_path<'a>(
+    contract_id: &'a [u8],
+    document_type_name: &'a str,
+) -> Vec<&'a [u8]> {
+    vec![
+        RootTree::ContractDocuments.into(),
+        contract_id,
+        b"1",
+        document_type_name.as_bytes(),
+        b"0",
+    ]
 }
 
 fn base58_value_as_bytes_from_hash_map(
@@ -266,7 +283,14 @@ impl Drive {
 
         let document = Document::from_cbor(document_cbor, owner_id)?;
 
-        self.add_document_for_contract(&document, document_cbor, &contract, document_type_name, owner_id, override_document)
+        self.add_document_for_contract(
+            &document,
+            document_cbor,
+            &contract,
+            document_type_name,
+            owner_id,
+            override_document,
+        )
     }
 
     pub fn add_document_for_contract(
@@ -278,27 +302,41 @@ impl Drive {
         owner_id: &[u8],
         override_document: bool,
     ) -> Result<u64, Error> {
-
         // second we need to construct the path for documents on the contract
         // the path is
         //  * Document and Contract root tree
         //  * Contract ID recovered from document
         //  * 0 to signify Documents and not Contract
-        let contract_document_type_path = contract_document_type_path(&contract.id, document_type_name);
+        let contract_document_type_path =
+            contract_document_type_path(&contract.id, document_type_name);
 
         // third we need to store the document for it's primary key
-        let mut primary_key_path = contract_documents_primary_key_path(&contract.id, document_type_name);
+        let mut primary_key_path =
+            contract_documents_primary_key_path(&contract.id, document_type_name);
         let document_element = Element::Item(Vec::from(document_cbor));
         let overrode;
         if override_document {
-            if self.grove.get(&primary_key_path, &document.id.clone()).is_ok() {
-                return self.update_document_for_contract(document, document_cbor, contract, document_type_name, owner_id);
+            if self
+                .grove
+                .get(&primary_key_path, &document.id.clone())
+                .is_ok()
+            {
+                return self.update_document_for_contract(
+                    document,
+                    document_cbor,
+                    contract,
+                    document_type_name,
+                    owner_id,
+                );
             }
             self.grove
                 .insert(&primary_key_path, document.id.clone(), document_element)?;
         } else {
-            let inserted =  self.grove
-                .insert_if_not_exists(&primary_key_path, document.id.clone(), document_element)?;
+            let inserted = self.grove.insert_if_not_exists(
+                &primary_key_path,
+                document.id.clone(),
+                document_element,
+            )?;
             if !inserted {
                 return Err(Error::CorruptedData(String::from("item already exists")));
             }
@@ -313,13 +351,15 @@ impl Drive {
                     "can not get document type from contract",
                 )))?;
 
-
         // fourth we need to store a reference to the document for each index
         for index in &document_type.indices {
             // at this point the contract path is to the contract documents
             // for each index the top index component will already have been added
             // when the contract itself was created
-            let mut index_path : Vec<Vec<u8>> = contract_document_type_path.iter().map(|&x| Vec::from(x)).collect();
+            let mut index_path: Vec<Vec<u8>> = contract_document_type_path
+                .iter()
+                .map(|&x| Vec::from(x))
+                .collect();
             let top_index_property =
                 index
                     .properties
@@ -335,7 +375,7 @@ impl Drive {
             match top_index_property.name.as_str() {
                 "$ownerId" => {
                     document_top_field = owner_id.to_vec();
-                },
+                }
                 &_ => {
                     document_top_field = document
                         .get_raw_for_contract(&top_index_property.name, &contract)
@@ -345,7 +385,7 @@ impl Drive {
                 }
             };
 
-            let index_path_slices : Vec<&[u8]> = index_path.iter().map(|x| x.as_slice()).collect();
+            let index_path_slices: Vec<&[u8]> = index_path.iter().map(|x| x.as_slice()).collect();
 
             // here we are inserting an empty tree that will have a subtree of all other index properties
             self.grove.insert_if_not_exists(
@@ -367,7 +407,8 @@ impl Drive {
                             "invalid contract indices",
                         )))?;
 
-                let index_path_slices : Vec<&[u8]> = index_path.iter().map(|x| x.as_slice()).collect();
+                let index_path_slices: Vec<&[u8]> =
+                    index_path.iter().map(|x| x.as_slice()).collect();
 
                 // here we are inserting an empty tree that will have a subtree of all other index properties
                 self.grove.insert_if_not_exists(
@@ -386,7 +427,8 @@ impl Drive {
                         "unable to get document field",
                     )))?;
 
-                let index_path_slices : Vec<&[u8]> = index_path.iter().map(|x| x.as_slice()).collect();
+                let index_path_slices: Vec<&[u8]> =
+                    index_path.iter().map(|x| x.as_slice()).collect();
 
                 // here we are inserting an empty tree that will have a subtree of all other index properties
                 self.grove.insert_if_not_exists(
@@ -405,7 +447,7 @@ impl Drive {
             let document_reference =
                 Element::Reference(primary_key_path.iter().map(|x| x.to_vec()).collect());
 
-            let index_path_slices : Vec<&[u8]> = index_path.iter().map(|x| x.as_slice()).collect();
+            let index_path_slices: Vec<&[u8]> = index_path.iter().map(|x| x.as_slice()).collect();
 
             // unique indexes will be stored under key "0"
             // non unique indices should have a tree at key "0" that has all elements based off of primary key
@@ -418,17 +460,22 @@ impl Drive {
                 )?;
                 index_path.push(b"0".to_vec());
 
-                let index_path_slices : Vec<&[u8]> = index_path.iter().map(|x| x.as_slice()).collect();
+                let index_path_slices: Vec<&[u8]> =
+                    index_path.iter().map(|x| x.as_slice()).collect();
 
                 // here we should return an error if the element already exists
                 self.grove
                     .insert(&index_path_slices, document.id.clone(), document_reference)?;
             } else {
-                let index_path_slices : Vec<&[u8]> = index_path.iter().map(|x| x.as_slice()).collect();
+                let index_path_slices: Vec<&[u8]> =
+                    index_path.iter().map(|x| x.as_slice()).collect();
 
                 // here we should return an error if the element already exists
-                let inserted = self.grove
-                    .insert_if_not_exists(&index_path_slices, b"0".to_vec(), document_reference)?;
+                let inserted = self.grove.insert_if_not_exists(
+                    &index_path_slices,
+                    b"0".to_vec(),
+                    document_reference,
+                )?;
                 if !inserted {
                     return Err(Error::CorruptedData(String::from("index already exists")));
                 }
@@ -448,7 +495,13 @@ impl Drive {
 
         let document = Document::from_cbor(document_cbor, owner_id)?;
 
-        self.update_document_for_contract(&document, document_cbor, &contract, document_type, owner_id)
+        self.update_document_for_contract(
+            &document,
+            document_cbor,
+            &contract,
+            document_type,
+            owner_id,
+        )
     }
 
     pub fn update_document_for_contract(
@@ -459,10 +512,21 @@ impl Drive {
         document_type: &str,
         owner_id: &[u8],
     ) -> Result<u64, Error> {
-
         // for now updating a document will delete the document, then insert a new document
-        self.delete_document_for_contract(document.id.clone().as_slice(), contract, document_type, owner_id)?;
-        self.add_document_for_contract(document, document_cbor, contract, document_type, owner_id, false)
+        self.delete_document_for_contract(
+            document.id.clone().as_slice(),
+            contract,
+            document_type,
+            owner_id,
+        )?;
+        self.add_document_for_contract(
+            document,
+            document_cbor,
+            contract,
+            document_type,
+            owner_id,
+            false,
+        )
     }
 
     pub fn delete_document_for_contract_cbor(
@@ -495,7 +559,8 @@ impl Drive {
         //  * Document and Contract root tree
         //  * Contract ID recovered from document
         //  * 0 to signify Documents and not Contract
-        let contract_documents_primary_key_path = contract_documents_primary_key_path(&contract.id, document_type_name);
+        let contract_documents_primary_key_path =
+            contract_documents_primary_key_path(&contract.id, document_type_name);
 
         // next we need to get the document from storage
         let document_element: Element = self
@@ -517,14 +582,18 @@ impl Drive {
         }
 
         let document = Document::from_cbor(
-            document_bytes.expect("Can't be none handled above")
-                .as_slice(), owner_id)?;
+            document_bytes
+                .expect("Can't be none handled above")
+                .as_slice(),
+            owner_id,
+        )?;
 
         // third we need to delete the document for it's primary key
         self.grove
             .delete(&contract_documents_primary_key_path, Vec::from(document_id))?;
 
-        let contract_document_type_path = contract_document_type_path(&contract.id, document_type_name);
+        let contract_document_type_path =
+            contract_document_type_path(&contract.id, document_type_name);
 
         // fourth we need delete all references to the document
         // to do this we need to go through each index
@@ -532,7 +601,10 @@ impl Drive {
             // at this point the contract path is to the contract documents
             // for each index the top index component will already have been added
             // when the contract itself was created
-            let mut index_path : Vec<Vec<u8>> = contract_document_type_path.iter().map(|&x| Vec::from(x)).collect();
+            let mut index_path: Vec<Vec<u8>> = contract_document_type_path
+                .iter()
+                .map(|&x| Vec::from(x))
+                .collect();
             let top_index_property =
                 index
                     .properties
@@ -548,7 +620,7 @@ impl Drive {
             match top_index_property.name.as_str() {
                 "$ownerId" => {
                     document_top_field = owner_id.to_vec();
-                },
+                }
                 &_ => {
                     document_top_field = document
                         .get_raw_for_contract(&top_index_property.name, &contract)
@@ -592,18 +664,19 @@ impl Drive {
             if !index.unique {
                 index_path.push(b"0".to_vec());
 
-                let index_path_slices : Vec<&[u8]> = index_path.iter().map(|x| x.as_slice()).collect();
+                let index_path_slices: Vec<&[u8]> =
+                    index_path.iter().map(|x| x.as_slice()).collect();
 
                 // here we should return an error if the element already exists
-                self.grove.delete(&index_path_slices, Vec::from(document_id))?;
+                self.grove
+                    .delete(&index_path_slices, Vec::from(document_id))?;
             } else {
-                let index_path_slices : Vec<&[u8]> = index_path.iter().map(|x| x.as_slice()).collect();
+                let index_path_slices: Vec<&[u8]> =
+                    index_path.iter().map(|x| x.as_slice()).collect();
 
                 // here we should return an error if the element already exists
                 self.grove.delete(&index_path_slices, b"0".to_vec())?;
             }
-
-
         }
         Ok(0)
     }
@@ -612,10 +685,10 @@ impl Drive {
 #[cfg(test)]
 mod tests {
     use crate::drive::Drive;
+    use rand::Rng;
     use serde::{Deserialize, Serialize};
     use std::{collections::HashMap, fs::File, io::BufReader, path::Path};
     use tempdir::TempDir;
-    use rand::Rng;
 
     fn json_document_to_cbor(path: impl AsRef<Path>) -> Vec<u8> {
         let file = File::open(path).expect("file not found");
@@ -648,46 +721,115 @@ mod tests {
     fn test_add_dashpay_documents() {
         let (mut drive, dashpay_cbor) = setup_dashpay("add");
 
-        let dashpay_cr_document_cbor = json_document_to_cbor("test/contract/dashpay/contact-request0.json");
+        let dashpay_cr_document_cbor =
+            json_document_to_cbor("test/contract/dashpay/contact-request0.json");
 
         let random_owner_id = rand::thread_rng().gen::<[u8; 32]>();
-        drive.add_document_for_contract_cbor(&dashpay_cr_document_cbor, &dashpay_cbor, "contactRequest", &random_owner_id, false).expect("expected to insert a document successfully");
+        drive
+            .add_document_for_contract_cbor(
+                &dashpay_cr_document_cbor,
+                &dashpay_cbor,
+                "contactRequest",
+                &random_owner_id,
+                false,
+            )
+            .expect("expected to insert a document successfully");
 
-        drive.add_document_for_contract_cbor(&dashpay_cr_document_cbor, &dashpay_cbor, "contactRequest", &random_owner_id, false).expect_err("expected not to be able to insert same document twice");
+        drive
+            .add_document_for_contract_cbor(
+                &dashpay_cr_document_cbor,
+                &dashpay_cbor,
+                "contactRequest",
+                &random_owner_id,
+                false,
+            )
+            .expect_err("expected not to be able to insert same document twice");
 
-        drive.add_document_for_contract_cbor(&dashpay_cr_document_cbor, &dashpay_cbor, "contactRequest", &random_owner_id, true).expect("expected to override a document successfully");
-
+        drive
+            .add_document_for_contract_cbor(
+                &dashpay_cr_document_cbor,
+                &dashpay_cbor,
+                "contactRequest",
+                &random_owner_id,
+                true,
+            )
+            .expect("expected to override a document successfully");
     }
 
     #[test]
     fn test_add_dashpay_many_non_conflicting_documents() {
         let (mut drive, dashpay_cbor) = setup_dashpay("add_no_conflict");
 
-        let dashpay_cr_document_cbor_0 = json_document_to_cbor("test/contract/dashpay/contact-request0.json");
+        let dashpay_cr_document_cbor_0 =
+            json_document_to_cbor("test/contract/dashpay/contact-request0.json");
 
-        let dashpay_cr_document_cbor_1 = json_document_to_cbor("test/contract/dashpay/contact-request1.json");
+        let dashpay_cr_document_cbor_1 =
+            json_document_to_cbor("test/contract/dashpay/contact-request1.json");
 
-        let dashpay_cr_document_cbor_2 = json_document_to_cbor("test/contract/dashpay/contact-request2.json");
+        let dashpay_cr_document_cbor_2 =
+            json_document_to_cbor("test/contract/dashpay/contact-request2.json");
 
         let random_owner_id = rand::thread_rng().gen::<[u8; 32]>();
-        drive.add_document_for_contract_cbor(&dashpay_cr_document_cbor_0, &dashpay_cbor, "contactRequest", &random_owner_id, false).expect("expected to insert a document successfully");
-        drive.add_document_for_contract_cbor(&dashpay_cr_document_cbor_1, &dashpay_cbor, "contactRequest", &random_owner_id, false).expect("expected to insert a document successfully");
-        drive.add_document_for_contract_cbor(&dashpay_cr_document_cbor_2, &dashpay_cbor, "contactRequest", &random_owner_id, false).expect("expected to insert a document successfully");
-
+        drive
+            .add_document_for_contract_cbor(
+                &dashpay_cr_document_cbor_0,
+                &dashpay_cbor,
+                "contactRequest",
+                &random_owner_id,
+                false,
+            )
+            .expect("expected to insert a document successfully");
+        drive
+            .add_document_for_contract_cbor(
+                &dashpay_cr_document_cbor_1,
+                &dashpay_cbor,
+                "contactRequest",
+                &random_owner_id,
+                false,
+            )
+            .expect("expected to insert a document successfully");
+        drive
+            .add_document_for_contract_cbor(
+                &dashpay_cr_document_cbor_2,
+                &dashpay_cbor,
+                "contactRequest",
+                &random_owner_id,
+                false,
+            )
+            .expect("expected to insert a document successfully");
     }
 
     #[test]
     fn test_add_dashpay_conflicting_unique_index_documents() {
         let (mut drive, dashpay_cbor) = setup_dashpay("add_conflict");
 
-        let dashpay_cr_document_cbor_0 = json_document_to_cbor("test/contract/dashpay/contact-request0.json");
+        let dashpay_cr_document_cbor_0 =
+            json_document_to_cbor("test/contract/dashpay/contact-request0.json");
 
-        let dashpay_cr_document_cbor_0_dup = json_document_to_cbor("test/contract/dashpay/contact-request0-dup-unique-index.json");
+        let dashpay_cr_document_cbor_0_dup =
+            json_document_to_cbor("test/contract/dashpay/contact-request0-dup-unique-index.json");
 
         let random_owner_id = rand::thread_rng().gen::<[u8; 32]>();
-        drive.add_document_for_contract_cbor(&dashpay_cr_document_cbor_0, &dashpay_cbor, "contactRequest", &random_owner_id, false).expect("expected to insert a document successfully");
-        drive.add_document_for_contract_cbor(&dashpay_cr_document_cbor_0_dup, &dashpay_cbor, "contactRequest", &random_owner_id, false).expect_err("expected not to be able to insert document with already existing unique index");
-
+        drive
+            .add_document_for_contract_cbor(
+                &dashpay_cr_document_cbor_0,
+                &dashpay_cbor,
+                "contactRequest",
+                &random_owner_id,
+                false,
+            )
+            .expect("expected to insert a document successfully");
+        drive
+            .add_document_for_contract_cbor(
+                &dashpay_cr_document_cbor_0_dup,
+                &dashpay_cbor,
+                "contactRequest",
+                &random_owner_id,
+                false,
+            )
+            .expect_err(
+                "expected not to be able to insert document with already existing unique index",
+            );
     }
 
     #[test]


### PR DESCRIPTION
Keeps track of the type of each document property in a contract.
Encodes values correctly based on field type.