### PR TITLE
fix: handle key not found error from grovedb

### DIFF
--- a/drive/src/query/mod.rs
+++ b/drive/src/query/mod.rs
@@ -1069,7 +1069,18 @@ impl<'a> DriveQuery<'a> {
             SizedQuery::new(final_query, Some(self.limit), Some(self.offset)),
         );
 
-        grove.get_path_query(&path_query, transaction)
+        let query_result = grove.get_path_query(&path_query, transaction);
+        match query_result {
+            Err(Error::InvalidPathKey(ref message)) => {
+                if message.starts_with("key not found in Merk:") {
+                    Ok((Vec::new(), 0))
+                } else {
+                   query_result
+                }
+            },
+            Err(e) => Err(e),
+            Ok(result) => Ok(result),
+        }
     }
 }
 

--- a/drive/tests/query_tests.rs
+++ b/drive/tests/query_tests.rs
@@ -186,7 +186,7 @@ fn test_query() {
         None,
     ).expect("query should be executed");
 
-    assert_eq!(results.len(), 1);
+    assert_eq!(results.len(), 0);
     //
     // let names: Vec<String> = results
     //     .into_iter()


### PR DESCRIPTION
grovedb returns an error if it cannot find a key at the subtree path
rs-drive was not handling this error until now, which caused it to
fail for queries with unknown keys.