### PR TITLE
fix: many insert commit fail

### DIFF
--- a/drive/tests/query_tests.rs
+++ b/drive/tests/query_tests.rs
@@ -56,6 +56,11 @@ pub fn setup(count: u32, seed: u64) -> (Drive, Contract, TempDir) {
     let db_transaction = storage.transaction();
 
     drive
+        .grove
+        .start_transaction()
+        .expect("transaction should be started");
+
+    drive
         .create_root_tree(Some(&db_transaction))
         .expect("expected to create root tree successfully");
 
@@ -65,11 +70,6 @@ pub fn setup(count: u32, seed: u64) -> (Drive, Contract, TempDir) {
         "tests/supporting_files/contract/family/family-contract.json",
         Some(&db_transaction),
     );
-
-    drive
-        .grove
-        .start_transaction()
-        .expect("transaction should be started");
 
     let people = Person::random_people(count, seed);
     for person in people {

--- a/drive/tests/query_tests.rs
+++ b/drive/tests/query_tests.rs
@@ -48,9 +48,9 @@ impl Person {
     }
 }
 
-pub fn setup(count: u32, seed: u64) -> (Drive, Contract) {
+pub fn setup(count: u32, seed: u64) -> (Drive, Contract, TempDir) {
     let tmp_dir = TempDir::new("family").unwrap();
-    let mut drive: Drive = Drive::open(tmp_dir).expect("expected to open Drive successfully");
+    let mut drive: Drive = Drive::open(&tmp_dir).expect("expected to open Drive successfully");
 
     let storage = drive.grove.storage();
     let db_transaction = storage.transaction();
@@ -94,12 +94,12 @@ pub fn setup(count: u32, seed: u64) -> (Drive, Contract) {
         .grove
         .commit_transaction(db_transaction)
         .expect("transaction should be committed");
-    (drive, contract)
+    (drive, contract, tmp_dir)
 }
 
 #[test]
 fn test_query_many() {
-    let (mut drive, contract) = setup(1600, 73509);
+    let (mut drive, contract, tmp_dir) = setup(1600, 73509);
     let storage = drive.grove.storage();
     let db_transaction = storage.transaction();
     let people = Person::random_people(10, 73409);
@@ -129,7 +129,7 @@ fn test_query_many() {
 
 #[test]
 fn test_query() {
-    let (mut drive, contract) = setup(10, 73509);
+    let (mut drive, contract, tmp_dir) = setup(10, 73509);
     let all_names = [
         "Adey".to_string(),
         "Briney".to_string(),
@@ -745,7 +745,7 @@ fn test_sql_query() {
     // These tests confirm that sql statements produce the same drive query
     // as their json counterparts, tests above confirm that the json queries
     // produce the correct result set
-    let (_, contract) = setup(10, 73509);
+    let (_, contract, tmp_dir) = setup(10, 73509);
     let person_document_type = contract
         .document_types
         .get("person")


### PR DESCRIPTION
for tests, we create a temp dir to temporarily hold the db
contents, before this fix the temp directory was created but
dropped before we were done with the database.

When inserting a lot of documents additional log files will get
created, because the tmp dir was already dropped, creation
of the additional log files failed.

This fix preserves the temp dir until we are done with operations
preventing creation error.