### PR TITLE
chrore: PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Environment name and version (e.g. Chrome 39, node.js 5.4):
+* Operating System and version (desktop, server, or mobile):
+* Link to your project:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the feature request in the Title above -->
+
+## Expected Behavior
+<!--- A clear and concise description of what you want to happen -->
+
+## Current Behavior
+<!--- Explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Suggest ideas of how to implement the addition or change -->
+
+## Alternatives Considered
+<!--- A clear and concise description of any alternative solutions or features you've considered -->
+
+## Additional Context
+<!--- Add any other context or screenshots about the feature request here. -->
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--- Provide a general summary of your changes in the Title above -->
+<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->
+
+## Issue being fixed or feature implemented
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+
+## What was done?
+<!--- Describe your changes in detail -->
+
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+
+## Breaking Changes
+<!--- Please describe any breaking changes your code introduces and verify that -->
+<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
+
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have added or updated relevant unit/integration/functional/e2e tests
+- [ ] I have made corresponding changes to the documentation
+
+**For repository code-owners and collaborators only**
+- [ ] I have assigned this pull request to a milestone


### PR DESCRIPTION
# Issue being fixed or implemented

This should help to make PRs/issues more consistent from all contributors by starting all new issues/PRs with the same templates as were added to various other platform repos (e.g. platform, tenderdash, etc.).

# What was done
Added a PR template and unique issue templates for both bug and feature request issues. The issue templates auto-assign the bug or enhancement label.
