### PR TITLE
fix: proposer with nil fees triggers next block

### DIFF
--- a/dash-abci/src/abci/messages.rs
+++ b/dash-abci/src/abci/messages.rs
@@ -41,6 +41,12 @@ pub struct FeesAggregate {
     // pub refunds_by_epoch: Vec<EpochRefund>,
 }
 
+impl FeesAggregate {
+    pub fn is_nil(&self) -> bool {
+        self.storage_fees == 0 && self.processing_fees == 0
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BlockEndResponse {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Proposer with nil fees (no transactions in block) added to epoch proposers. It leads to app hash change, which triggers the next block in tenderdash. In the end, we have infinite block generation and high load on the network. 

## What was done?
<!--- Describe your changes in detail -->
- Do not add proposer if block fees are nil

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
