### PR TITLE
fix: duplicate batched storage fee update

### DIFF
--- a/dash-abci/src/abci/handlers.rs
+++ b/dash-abci/src/abci/handlers.rs
@@ -363,7 +363,7 @@ mod tests {
                             storage_fees: storage_fees_per_block,
                         },
                     };
-                    
+
                     let block_end_response = platform
                         .block_end(block_end_request, Some(&transaction))
                         .expect(

--- a/dash-abci/src/abci/handlers.rs
+++ b/dash-abci/src/abci/handlers.rs
@@ -364,6 +364,10 @@ mod tests {
                         },
                     };
 
+                    if day == 37 {
+                        dbg!("here");
+                    }
+
                     let block_end_response = platform
                         .block_end(block_end_request, Some(&transaction))
                         .expect(

--- a/dash-abci/src/abci/handlers.rs
+++ b/dash-abci/src/abci/handlers.rs
@@ -363,11 +363,7 @@ mod tests {
                             storage_fees: storage_fees_per_block,
                         },
                     };
-
-                    if day == 37 {
-                        dbg!("here");
-                    }
-
+                    
                     let block_end_response = platform
                         .block_end(block_end_request, Some(&transaction))
                         .expect(

--- a/dash-abci/src/execution/fee_pools/distribute_storage_pool.rs
+++ b/dash-abci/src/execution/fee_pools/distribute_storage_pool.rs
@@ -63,7 +63,8 @@ impl Platform {
                     .or_else(|e| match e {
                         // In case if we have a gap between current and previous epochs
                         // multiple future epochs could be created in the current batch
-                        error::Error::GroveDB(grovedb::Error::PathNotFound(_)) => Ok(0u64),
+                        error::Error::GroveDB(grovedb::Error::PathNotFound(_))
+                        | error::Error::GroveDB(grovedb::Error::PathKeyNotFound(_)) => Ok(0u64),
                         _ => Err(e),
                     })?;
 

--- a/dash-abci/src/execution/fee_pools/process_block_fees.rs
+++ b/dash-abci/src/execution/fee_pools/process_block_fees.rs
@@ -49,7 +49,7 @@ impl Platform {
 
         for epoch_index in last_initiated_epoch_index..=epoch_info.current_epoch_index {
             let next_thousandth_epoch = Epoch::new(epoch_index + PERPETUAL_STORAGE_EPOCHS);
-            next_thousandth_epoch.add_init_empty_operations_no_storage(batch);
+            next_thousandth_epoch.add_init_empty_without_storage_operations(batch);
         }
 
         // init current epoch pool for processing
@@ -262,6 +262,7 @@ mod tests {
 
                 let thousandth_epoch = Epoch::new(next_thousandth_epoch.index - 1);
 
+                // TODO: We should check that storage pool key wasn't created
                 let aggregate_storage_fees = platform
                     .drive
                     .get_epoch_storage_credits_for_distribution(&thousandth_epoch, transaction)

--- a/dash-abci/src/execution/fee_pools/process_block_fees.rs
+++ b/dash-abci/src/execution/fee_pools/process_block_fees.rs
@@ -262,7 +262,6 @@ mod tests {
 
                 let thousandth_epoch = Epoch::new(next_thousandth_epoch.index - 1);
 
-                // TODO: We should check that storage pool key wasn't created
                 let aggregate_storage_fees = platform
                     .drive
                     .get_epoch_storage_credits_for_distribution(&thousandth_epoch, transaction)

--- a/dash-abci/src/execution/fee_pools/process_block_fees.rs
+++ b/dash-abci/src/execution/fee_pools/process_block_fees.rs
@@ -49,7 +49,7 @@ impl Platform {
 
         for epoch_index in last_initiated_epoch_index..=epoch_info.current_epoch_index {
             let next_thousandth_epoch = Epoch::new(epoch_index + PERPETUAL_STORAGE_EPOCHS);
-            next_thousandth_epoch.add_init_empty_operations(batch);
+            next_thousandth_epoch.add_init_empty_operations_no_storage(batch);
         }
 
         // init current epoch pool for processing
@@ -141,12 +141,6 @@ impl Platform {
             transaction,
             &mut batch,
         )?;
-
-        let results = batch.verify_consistency_of_operations();
-
-        if !results.is_empty() {
-            dbg!(results);
-        }
 
         self.drive.grove_apply_batch(batch, false, transaction)?;
 

--- a/dash-abci/src/execution/fee_pools/process_block_fees.rs
+++ b/dash-abci/src/execution/fee_pools/process_block_fees.rs
@@ -142,6 +142,12 @@ impl Platform {
             &mut batch,
         )?;
 
+        let results = batch.verify_consistency_of_operations();
+
+        if !results.is_empty() {
+            dbg!(results);
+        }
+
         self.drive.grove_apply_batch(batch, false, transaction)?;
 
         Ok(ProcessedBlockFeesResult {

--- a/drive/src/drive/batch.rs
+++ b/drive/src/drive/batch.rs
@@ -67,7 +67,7 @@ impl GroveDbOpBatch {
             op: Op::Insert { element },
         })
     }
-    
+
     pub fn verify_consistency_of_operations(&self) -> GroveDbOpConsistencyResults {
         GroveDbOp::verify_consistency_of_operations(&self.operations)
     }

--- a/drive/src/drive/batch.rs
+++ b/drive/src/drive/batch.rs
@@ -1,5 +1,5 @@
 use crate::drive::flags::StorageFlags;
-use grovedb::batch::{GroveDbOp, Op};
+use grovedb::batch::{GroveDbOp, GroveDbOpConsistencyResults, Op};
 use grovedb::Element;
 
 // TODO move to GroveDB
@@ -66,5 +66,9 @@ impl GroveDbOpBatch {
             key,
             op: Op::Insert { element },
         })
+    }
+    
+    pub fn verify_consistency_of_operations(&self) -> GroveDbOpConsistencyResults {
+        GroveDbOp::verify_consistency_of_operations(&self.operations)
     }
 }

--- a/drive/src/drive/grove_operations.rs
+++ b/drive/src/drive/grove_operations.rs
@@ -824,6 +824,7 @@ impl Drive {
                 ops.operations,
                 Some(BatchApplyOptions {
                     validate_insertion_does_not_override: validate,
+                    disable_operation_consistency_check: false,
                 }),
                 transaction,
             );
@@ -871,6 +872,7 @@ impl Drive {
             ops.operations,
             Some(BatchApplyOptions {
                 validate_insertion_does_not_override: validate,
+                disable_operation_consistency_check: false,
             }),
         );
         push_drive_operation_result(cost_context, drive_operations)

--- a/drive/src/fee_pools/epochs/operations_factory.rs
+++ b/drive/src/fee_pools/epochs/operations_factory.rs
@@ -34,12 +34,12 @@ impl Epoch {
             .update_proposer_block_count_operation(proposer_pro_tx_hash, proposed_block_count + 1))
     }
 
-    pub fn add_init_empty_operations_no_storage(&self, batch: &mut GroveDbOpBatch) {
+    pub fn add_init_empty_without_storage_operations(&self, batch: &mut GroveDbOpBatch) {
         batch.add_insert_empty_tree(pools_vec_path(), self.key.to_vec());
     }
 
     pub fn add_init_empty_operations(&self, batch: &mut GroveDbOpBatch) {
-        batch.add_insert_empty_tree(pools_vec_path(), self.key.to_vec());
+        self.add_init_empty_without_storage_operations(batch);
 
         // init storage fee item to 0
         batch.push(self.update_storage_credits_for_distribution_operation(0));

--- a/drive/src/fee_pools/epochs/operations_factory.rs
+++ b/drive/src/fee_pools/epochs/operations_factory.rs
@@ -34,6 +34,10 @@ impl Epoch {
             .update_proposer_block_count_operation(proposer_pro_tx_hash, proposed_block_count + 1))
     }
 
+    pub fn add_init_empty_operations_no_storage(&self, batch: &mut GroveDbOpBatch) {
+        batch.add_insert_empty_tree(pools_vec_path(), self.key.to_vec());
+    }
+
     pub fn add_init_empty_operations(&self, batch: &mut GroveDbOpBatch) {
         batch.add_insert_empty_tree(pools_vec_path(), self.key.to_vec());
 


### PR DESCRIPTION
Contrary to the name of the branch, this fixes the issue instead of disabling the check.

## Issue being fixed or feature implemented
Sometimes two operations would be in the same branch. Basically if there was a period when the chain was stalled when it started again we would insert a storage pool with 0 credits, and in the same batch try to put credits in that storage pool.

## What was done?
Storage pools don't need to be initialized. If they aren't on disk they are assumed to be at 0 credits.


## How Has This Been Tested?
All unit tests now pass

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
