### PR TITLE
chore(dpp)!: re-enable limited array support for data contracts

### DIFF
--- a/dpp/src/data_contract/extra/document_type.rs
+++ b/dpp/src/data_contract/extra/document_type.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use crate::data_contract::extra::ArrayFieldType;
 use ciborium::value::Value;
 use serde::{Deserialize, Serialize};
 
@@ -224,10 +225,11 @@ impl DocumentType {
                                 ));
                             }
                         }
-                        None => {
-                            return Err(ContractError::Unsupported("arrays not yet supported"));
-                            //DocumentFieldType::Array()
-                        }
+                        // TODO: Contract indices and new encoding format don't support arrays
+                        //   but we still can use them as document fields with current cbor encoding
+                        //   This is a temporary workaround to bring back v0.22 behavior and should be
+                        //   replaced with a proper array support in future versions
+                        None => DocumentFieldType::Array(ArrayFieldType::Boolean),
                     };
 
                     document_properties.insert(

--- a/dpp/src/tests/fixtures/get_data_contract.rs
+++ b/dpp/src/tests/fixtures/get_data_contract.rs
@@ -125,6 +125,12 @@ pub fn get_data_contract_fixture(owner_id: Option<Identifier>) -> DataContract {
             "properties": {
                 "name": {
                     "type": "string"
+                },
+                "array": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
At some point, when we moved contract logic from Drive to DPP we broke limited array field support what we have in v0.22 https://github.com/dashpay/rs-platform/blob/ba58c2fadd28414dcbd0cdb9b6e6c4480f421857/drive/src/contract/mod.rs#L411

## What was done?
<!--- Describe your changes in detail -->
- Add a temporary workaround for array fields as we had in previous versions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated contract fixture to use array fields.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
This breaks compatibility with v0.23 but not with v0.22

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
