### PR TITLE
fix: bump up gcc to 11 and set rust toolchain to stable

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Setup Node.JS
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: "16"
 
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
-          default: true
+          toolchain: stable
+          default: tru
 
       - name: Install NPM deps
         run: npm ci
@@ -51,12 +51,12 @@ jobs:
       - name: Setup Node.JS
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: "16"
 
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           default: true
 
       - name: Install NPM deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ matrix.os == 'macos-11' }}
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           default: true
           target: ${{ steps.set-target.outputs.result }}
 

--- a/node/docker/build.sh
+++ b/node/docker/build.sh
@@ -22,8 +22,8 @@ fi
 curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 apt install -y nodejs
 
-## Update nightly
-rustup update nightly
+## Update stable
+rustup update stable
 
 ## Install build target
 rustup target install $target

--- a/node/docker/build.sh
+++ b/node/docker/build.sh
@@ -15,7 +15,7 @@ apt update
 apt install -y gcc-multilib
 if [[ $target = "aarch64-unknown-linux-gnu" ]]
 then
-    apt install -y gcc-aarch64-linux-gnu libstdc++-9-dev-arm64-cross
+    apt install -y gcc-aarch64-linux-gnu libstdc++-11-dev-arm64-cross
 fi
 
 ## Install Node.JS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Failing release build for `aarch64-unknown-linux-gnu`: 
Failed job: https://github.com/dashpay/rs-platform/actions/runs/3268032503/jobs/5373960282
```
   = note: /usr/lib/gcc-cross/aarch64-linux-gnu/11/../../../../aarch64-linux-gnu/bin/ld: cannot find -lstdc++: No such file or directory
          collect2: error: ld returned 1 exit status
      

error: could not compile `node` due to previous error
Did not copy "cdylib:node"
```

## What was done?
<!--- Describe your changes in detail -->

- set the rust toolchain for release build to `stable`
- bump up the GCC  version to 11 (as it has changed in docker `musl` image)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
